### PR TITLE
Change Class SofaTracerSpan's startTime/endTime to microsecond precision

### DIFF
--- a/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springmvc/SpringMvcDigestEncoder.java
+++ b/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springmvc/SpringMvcDigestEncoder.java
@@ -41,7 +41,7 @@ public class SpringMvcDigestEncoder extends AbstractDigestSpanEncoder {
         XStringBuilder xsb = new XStringBuilder();
         xsb.reset();
         //日志打印时间
-        xsb.append(Timestamp.format(span.getEndTime()));
+        xsb.append(Timestamp.format(span.getEndTimeMillis()));
         appendSlot(xsb, span);
         return xsb.toString();
     }
@@ -70,7 +70,7 @@ public class SpringMvcDigestEncoder extends AbstractDigestSpanEncoder {
         //Response Body 大小，单位为byte
         xsb.append((responseSize == null ? 0L : responseSize.longValue()) + SofaTracerConstant.BYTE);
         //请求耗时（MS）
-        xsb.append((sofaTracerSpan.getEndTime() - sofaTracerSpan.getStartTime())
+        xsb.append((sofaTracerSpan.getEndTimeMillis() - sofaTracerSpan.getStartTimeMillis())
                    + SofaTracerConstant.MS);
         xsb.append(tagWithStr.get(CommonSpanTags.CURRENT_THREAD_NAME));
         //穿透数据放在最后

--- a/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springmvc/SpringMvcDigestJsonEncoder.java
+++ b/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springmvc/SpringMvcDigestJsonEncoder.java
@@ -38,7 +38,7 @@ public class SpringMvcDigestJsonEncoder extends AbstractDigestSpanEncoder {
     public String encode(SofaTracerSpan span) throws IOException {
         JsonStringBuilder jsonStringBuilder = new JsonStringBuilder();
         //日志打印时间
-        jsonStringBuilder.appendBegin("time", Timestamp.format(span.getEndTime()));
+        jsonStringBuilder.appendBegin("time", Timestamp.format(span.getEndTimeMillis()));
         appendSlot(jsonStringBuilder, span);
         return jsonStringBuilder.toString();
     }
@@ -73,7 +73,7 @@ public class SpringMvcDigestJsonEncoder extends AbstractDigestSpanEncoder {
             : responseSize.longValue()));
         //请求耗时（MS）
         jsonStringBuilder.append("time.cost.milliseconds",
-            (sofaTracerSpan.getEndTime() - sofaTracerSpan.getStartTime()));
+            (sofaTracerSpan.getEndTimeMillis() - sofaTracerSpan.getStartTimeMillis()));
         jsonStringBuilder.append(CommonSpanTags.CURRENT_THREAD_NAME,
             tagWithStr.get(CommonSpanTags.CURRENT_THREAD_NAME));
         //穿透数据放在最后

--- a/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springmvc/SpringMvcJsonStatReporter.java
+++ b/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springmvc/SpringMvcJsonStatReporter.java
@@ -66,7 +66,7 @@ public class SpringMvcJsonStatReporter extends SpringMvcStatReporter {
         statKey.setEnd(TracerUtils.getLoadTestMark(sofaTracerSpan));
         //value
         //次数和耗时，最后一个耗时是单独打印的字段
-        long duration = sofaTracerSpan.getEndTime() - sofaTracerSpan.getStartTime();
+        long duration = sofaTracerSpan.getEndTimeMillis() - sofaTracerSpan.getStartTimeMillis();
         long values[] = new long[] { 1, duration };
         //reserve
         this.addStat(statKey, values);

--- a/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springmvc/SpringMvcStatReporter.java
+++ b/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springmvc/SpringMvcStatReporter.java
@@ -56,7 +56,7 @@ public class SpringMvcStatReporter extends AbstractSofaTracerStatisticReporter {
         statKey.setLoadTest(TracerUtils.isLoadTest(sofaTracerSpan));
 
         //次数和耗时，最后一个耗时是单独打印的字段
-        long duration = sofaTracerSpan.getEndTime() - sofaTracerSpan.getStartTime();
+        long duration = sofaTracerSpan.getEndTimeMillis() - sofaTracerSpan.getStartTimeMillis();
         long values[] = new long[] { 1, duration };
         this.addStat(statKey, values);
     }

--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/SofaTracer.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/SofaTracer.java
@@ -29,6 +29,7 @@ import com.alipay.common.tracer.core.samplers.SamplingStatus;
 import com.alipay.common.tracer.core.span.SofaTracerSpan;
 import com.alipay.common.tracer.core.span.SofaTracerSpanReferenceRelationship;
 import com.alipay.common.tracer.core.utils.AssertUtils;
+import com.alipay.common.tracer.core.utils.MicroTimestamp;
 import com.alipay.common.tracer.core.utils.StringUtils;
 import io.opentracing.References;
 import io.opentracing.Span;
@@ -285,7 +286,8 @@ public class SofaTracer implements Tracer {
                 sofaTracerSpanContext = this.createRootSpanContext();
             }
 
-            long begin = this.startTime > 0 ? this.startTime : System.currentTimeMillis();
+            long begin = this.startTime > 0 ? this.startTime : MicroTimestamp.INSTANCE
+                .currentMicroSeconds();
             SofaTracerSpan sofaTracerSpan = new SofaTracerSpan(SofaTracer.this, begin,
                 this.references, this.operationName, sofaTracerSpanContext, this.tags);
             return sofaTracerSpan;

--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/reporter/common/CommonSpanEncoder.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/reporter/common/CommonSpanEncoder.java
@@ -46,7 +46,7 @@ public class CommonSpanEncoder implements SpanEncoder<CommonLogSpan> {
         SofaTracerSpanContext spanContext = commonLogSpan.getSofaTracerSpanContext();
         XStringBuilder xsb = new XStringBuilder();
         //报告开始的时间作为打印的时间,不存在完成时间
-        xsb.append(Timestamp.format(commonLogSpan.getStartTime()))
+        xsb.append(Timestamp.format(commonLogSpan.getStartTimeMillis()))
             //保证构造common也携带过来
             .append(commonLogSpan.getTagsWithStr().get(SpanTags.CURR_APP_TAG.getKey()))
             .append(spanContext.getTraceId()).append(spanContext.getSpanId());

--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/tracer/AbstractTracer.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/tracer/AbstractTracer.java
@@ -29,6 +29,7 @@ import com.alipay.common.tracer.core.reporter.stat.AbstractSofaTracerStatisticRe
 import com.alipay.common.tracer.core.span.CommonSpanTags;
 import com.alipay.common.tracer.core.span.LogData;
 import com.alipay.common.tracer.core.span.SofaTracerSpan;
+import com.alipay.common.tracer.core.utils.MicroTimestamp;
 import com.alipay.common.tracer.core.utils.StringUtils;
 import io.opentracing.tag.Tags;
 
@@ -194,8 +195,9 @@ public abstract class AbstractTracer {
                 if (sofaTracerSpanContext == null) {
                     sofaTracerSpanContext = SofaTracerSpanContext.rootStart();
                 }
-                sofaTracerSpanServer = this.genSeverSpanInstance(System.currentTimeMillis(),
-                    StringUtils.EMPTY_STRING, sofaTracerSpanContext, null);
+                sofaTracerSpanServer = this.genSeverSpanInstance(
+                    MicroTimestamp.INSTANCE.currentMicroSeconds(), StringUtils.EMPTY_STRING,
+                    sofaTracerSpanContext, null);
             } else {
                 //没有 setLogContextAndPush 操作,会 span == null,所以不会抛出 cast 异常
                 sofaTracerSpanServer = serverSpan;
@@ -274,8 +276,9 @@ public abstract class AbstractTracer {
         SofaTracerSpanContext spanContext = SofaTracerSpanContext.rootStart();
         spanContext.addBizBaggage(bizBaggage);
         spanContext.addSysBaggage(sysBaggage);
-        SofaTracerSpan span = this.genSeverSpanInstance(System.currentTimeMillis(),
-            StringUtils.EMPTY_STRING, spanContext, null);
+        SofaTracerSpan span = this.genSeverSpanInstance(
+            MicroTimestamp.INSTANCE.currentMicroSeconds(), StringUtils.EMPTY_STRING, spanContext,
+            null);
         return span;
     }
 

--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/utils/MicroTimestamp.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/utils/MicroTimestamp.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.common.tracer.core.utils;
+
+public class MicroTimestamp {
+
+    public static final MicroTimestamp INSTANCE = new MicroTimestamp(); ;
+
+    private volatile long              startDate;
+    private volatile long              startNanoseconds;
+
+    private MicroTimestamp() {
+        this.startDate = System.currentTimeMillis();
+        this.startNanoseconds = System.nanoTime();
+    }
+
+    /**
+     * retrun value's part of Microsecond not reflect wall time, only use to
+     * measurement call duration.
+     */
+    public long currentMicroSeconds() {
+        long nanoSpan = System.nanoTime() - this.startNanoseconds;
+
+        if (nanoSpan < 0) {
+            synchronized (this) {
+                nanoSpan = System.nanoTime() - this.startNanoseconds;
+                if (nanoSpan < 0) {
+                    this.startDate = System.currentTimeMillis();
+                    this.startNanoseconds = System.nanoTime();
+                    nanoSpan = System.nanoTime() - this.startNanoseconds;
+                }
+            }
+        }
+        return (this.startDate * 1000 + nanoSpan / 1000);
+    }
+}

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/manager/ClientSpanEncoder.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/manager/ClientSpanEncoder.java
@@ -41,7 +41,7 @@ public class ClientSpanEncoder implements SpanEncoder<SofaTracerSpan> {
 
         SofaTracerSpanContext spanContext = span.getSofaTracerSpanContext();
         xsb.reset();
-        xsb.append(Timestamp.format(span.getEndTime()));
+        xsb.append(Timestamp.format(span.getEndTimeMillis()));
         //traceId
         xsb.append(spanContext.getTraceId());
         //spanId

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/manager/ManagerTestUtil.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/manager/ManagerTestUtil.java
@@ -19,6 +19,7 @@ package com.alipay.common.tracer.core.appender.manager;
 import com.alipay.common.tracer.core.SofaTracer;
 import com.alipay.common.tracer.core.context.span.SofaTracerSpanContext;
 import com.alipay.common.tracer.core.span.SofaTracerSpan;
+import com.alipay.common.tracer.core.utils.MicroTimestamp;
 
 import java.io.File;
 
@@ -49,7 +50,7 @@ public class ManagerTestUtil {
         SofaTracerSpanContext spanContext = new SofaTracerSpanContext("traceID" + sequence,
             "spanId", "parentId", false);
         SofaTracerSpan span = new SofaTracerSpan(new SofaTracer.Builder("tracerType").build(),
-            System.currentTimeMillis(), "callServiceName", spanContext, null);
+            MicroTimestamp.INSTANCE.currentMicroSeconds(), "callServiceName", spanContext, null);
         span.setLogType("logType" + sequence);
 
         return span;

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/reporter/common/CommonTracerManagerTest.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/reporter/common/CommonTracerManagerTest.java
@@ -21,6 +21,7 @@ import com.alipay.common.tracer.core.base.AbstractTestBase;
 import com.alipay.common.tracer.core.context.span.SofaTracerSpanContext;
 import com.alipay.common.tracer.core.reporter.type.TracerSystemLogEnum;
 import com.alipay.common.tracer.core.span.CommonLogSpan;
+import com.alipay.common.tracer.core.utils.MicroTimestamp;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,8 +57,8 @@ public class CommonTracerManagerTest extends AbstractTestBase {
         String logType = "test-register.log";
         CommonTracerManager.register(logType, "", "");
         CommonLogSpan commonLogSpan = new CommonLogSpan(this.sofaTracer,
-            System.currentTimeMillis(), "testReportProfile", SofaTracerSpanContext.rootStart(),
-            null);
+            MicroTimestamp.INSTANCE.currentMicroSeconds(), "testReportProfile",
+            SofaTracerSpanContext.rootStart(), null);
         assertTrue(CommonTracerManager.isAppenderExist(logType));
         //注意：对于 commonSpan 一定要设置日志类型
         commonLogSpan.setLogType(logType);
@@ -81,8 +82,8 @@ public class CommonTracerManagerTest extends AbstractTestBase {
         String fileName = "test.log.char";
         CommonTracerManager.register(logType, fileName, "", "");
         CommonLogSpan commonLogSpan = new CommonLogSpan(this.sofaTracer,
-            System.currentTimeMillis(), "testReportProfile", SofaTracerSpanContext.rootStart(),
-            null);
+            MicroTimestamp.INSTANCE.currentMicroSeconds(), "testReportProfile",
+            SofaTracerSpanContext.rootStart(), null);
         assertTrue(CommonTracerManager.isAppenderExist(logTypeStr));
         //注意：对于 commonSpan 一定要设置日志类型
         commonLogSpan.setLogType(logTypeStr);
@@ -113,8 +114,8 @@ public class CommonTracerManagerTest extends AbstractTestBase {
             initSize = FileUtils.readLines(f).size();
         }
 
-        CommonTracerManager.reportError(new CommonLogSpan(this.sofaTracer, System
-            .currentTimeMillis(), "testReportProfile", SofaTracerSpanContext.rootStart(), null));
+        CommonTracerManager.reportError(new CommonLogSpan(this.sofaTracer, MicroTimestamp.INSTANCE
+            .currentMicroSeconds(), "testReportProfile", SofaTracerSpanContext.rootStart(), null));
         File file = new File(logDirectoryPath + File.separator + logType);
         assertTrue("\n" + file, file.exists());
         Thread.sleep(2000);
@@ -128,8 +129,9 @@ public class CommonTracerManagerTest extends AbstractTestBase {
      */
     @Test
     public void testReportError() throws Exception {
-        CommonTracerManager.reportProfile(new CommonLogSpan(this.sofaTracer, System
-            .currentTimeMillis(), "testReportProfile", SofaTracerSpanContext.rootStart(), null));
+        CommonTracerManager.reportProfile(new CommonLogSpan(this.sofaTracer,
+            MicroTimestamp.INSTANCE.currentMicroSeconds(), "testReportProfile",
+            SofaTracerSpanContext.rootStart(), null));
         String logType = TracerSystemLogEnum.RPC_PROFILE.getDefaultLogName();
         File file = new File(logDirectoryPath + File.separator + logType);
         assertTrue("\n" + file, file.exists());

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/reporter/digest/DiskReporterImplTest.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/reporter/digest/DiskReporterImplTest.java
@@ -25,12 +25,14 @@ import com.alipay.common.tracer.core.reporter.stat.SofaTracerStatisticReporter;
 import com.alipay.common.tracer.core.span.SofaTracerSpan;
 import com.alipay.common.tracer.core.tracertest.encoder.ClientSpanEncoder;
 import com.alipay.common.tracer.core.tracertest.type.TracerTestLogEnum;
+import com.alipay.common.tracer.core.utils.MicroTimestamp;
 import com.alipay.common.tracer.core.utils.StringUtils;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.charset.MalformedInputException;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -185,7 +187,8 @@ public class DiskReporterImplTest extends AbstractTestBase {
 
         private void processCommand() {
             SofaTracerSpan span = new SofaTracerSpan(mock(SofaTracer.class),
-                System.currentTimeMillis(), "open", SofaTracerSpanContext.rootStart(), null);
+                MicroTimestamp.INSTANCE.currentMicroSeconds(), "open",
+                SofaTracerSpanContext.rootStart(), null);
             this.reporter.digestReport(span);
         }
 

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/tracertest/SofaTracerTest.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/tracertest/SofaTracerTest.java
@@ -505,7 +505,7 @@ public class SofaTracerTest extends AbstractTestBase {
      */
     @Test
     public void testWithStartTimestampMicroseconds() throws Exception {
-        long startTime = 111;
+        long startTime = 1111;
         //create
         SofaTracerSpan spanParent = (SofaTracerSpan) this.sofaTracer
             .buildSpan("testWithStartTimestampMicroseconds")
@@ -513,6 +513,7 @@ public class SofaTracerTest extends AbstractTestBase {
             .start();
         //
         assertEquals(startTime, spanParent.getStartTime());
+        assertEquals(startTime / 1000, spanParent.getStartTimeMillis());
     }
 
     /**

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/tracertest/encoder/ClientSpanEncoder.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/tracertest/encoder/ClientSpanEncoder.java
@@ -41,7 +41,7 @@ public class ClientSpanEncoder implements SpanEncoder<SofaTracerSpan> {
         SofaTracerSpanContext spanContext = span.getSofaTracerSpanContext();
         xsb.reset();
         //
-        xsb.append(Timestamp.format(span.getEndTime()));
+        xsb.append(Timestamp.format(span.getEndTimeMillis()));
         //traceId
         xsb.append(spanContext.getTraceId());
         //spanId

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/tracertest/encoder/ServerSpanEncoder.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/tracertest/encoder/ServerSpanEncoder.java
@@ -37,7 +37,7 @@ public class ServerSpanEncoder extends ClientSpanEncoder implements SpanEncoder<
     //        SofaTracerSpanContext spanContext = span.getSofaTracerSpanContext();
     //        xsb.reset();
     //
-    //        xsb.append(Timestamp.format(span.getStartTime())).append(span.getTagsWithStr())
+    //        xsb.append(Timestamp.format(span.getStartTimeMillis())).append(span.getTagsWithStr())
     //            .append(span.getTagsWithBool().toString()).append(span.getTagsWithNumber().toString())
     //            .appendEnd(spanContext.getBaggage());
     //

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/utils/MicroTimestampTest.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/utils/MicroTimestampTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.common.tracer.core.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MicroTimestampTest {
+    @Test
+    public void testSingleTon() {
+        MicroTimestamp instance1 = MicroTimestamp.INSTANCE;
+        MicroTimestamp instance2 = MicroTimestamp.INSTANCE;
+
+        assertEquals(instance1, instance2);
+        assertTrue(instance1 == instance2);
+    }
+
+    @Test
+    public void testCurrentMicroSeconds() throws InterruptedException {
+        long startMicros = MicroTimestamp.INSTANCE.currentMicroSeconds();
+        long endMicros = MicroTimestamp.INSTANCE.currentMicroSeconds();
+        assertTrue(startMicros > 0);
+        assertTrue(endMicros > 0);
+        assertTrue(endMicros >= startMicros);
+    }
+
+}

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/utils/TracerUtilsTest.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/utils/TracerUtilsTest.java
@@ -142,8 +142,9 @@ public class TracerUtilsTest {
     public void testCheckBaggageLength() {
         SofaTracer sofaTracer = mock(SofaTracer.class);
         SofaTracerSpanContext sofaTracerSpanContext = new SofaTracerSpanContext();
-        SofaTracerSpan sofaTracerSpan = new SofaTracerSpan(sofaTracer, System.currentTimeMillis(),
-            "mock", sofaTracerSpanContext, new HashMap<String, Object>());
+        SofaTracerSpan sofaTracerSpan = new SofaTracerSpan(sofaTracer,
+            MicroTimestamp.INSTANCE.currentMicroSeconds(), "mock", sofaTracerSpanContext,
+            new HashMap<String, Object>());
         assertTrue(TracerUtils.checkBaggageLength(sofaTracerSpan, "key", "value"));
     }
 

--- a/tracer-samples/tracer-sample-with-zipkin/src/main/resources/application.properties
+++ b/tracer-samples/tracer-sample-with-zipkin/src/main/resources/application.properties
@@ -22,4 +22,4 @@ logging.path=./logs
 # enable zipkin
 com.alipay.sofa.tracer.zipkin.enabled=true
 # zipkin server url
-com.alipay.sofa.tracer.zipkin.baseUrl=http://zipkin-cloud.host.net:9411
+com.alipay.sofa.tracer.zipkin.baseUrl=http://127.0.0.1:9411

--- a/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/zipkin/ZipkinSofaTracerSpanRemoteReporter.java
+++ b/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/zipkin/ZipkinSofaTracerSpanRemoteReporter.java
@@ -98,10 +98,9 @@ public class ZipkinSofaTracerSpanRemoteReporter implements SpanReportListener, F
         //baggage
         this.addZipkinBinaryAnnotationsWithBaggage(zipkinSpanBuilder, sofaTracerSpan);
         // Zipkin is in nanosecond :timestamp reference : zipkin.storage.QueryRequest.test()
-        zipkinSpanBuilder.timestamp(sofaTracerSpan.getStartTime() * 1000);
+        zipkinSpanBuilder.timestamp(sofaTracerSpan.getStartTime());
         // Zipkin is in nanosecond
-        zipkinSpanBuilder
-            .duration((sofaTracerSpan.getEndTime() - sofaTracerSpan.getStartTime()) * 1000);
+        zipkinSpanBuilder.duration(sofaTracerSpan.getDurationMicroseconds());
         //traceId
         SofaTracerSpanContext sofaTracerSpanContext = sofaTracerSpan.getSofaTracerSpanContext();
         zipkinSpanBuilder.traceId(traceIdToId(sofaTracerSpanContext.getTraceId()));
@@ -191,7 +190,7 @@ public class ZipkinSofaTracerSpanRemoteReporter implements SpanReportListener, F
                 //ignore event key
                 Annotation zipkinAnnotation = Annotation.builder()
                     // Zipkin is in nanosecond
-                    .timestamp(logData.getTime() * 1000).value(entry.getValue().toString())
+                    .timestamp(logData.getTime()).value(entry.getValue().toString())
                     .endpoint(endpoint).build();
                 zipkinSpan.addAnnotation(zipkinAnnotation);
             }

--- a/tracer-test/core-test/src/test/java/com/alipay/common/tracer/test/core/sofatracer/SofaTracerDemoTest.java
+++ b/tracer-test/core-test/src/test/java/com/alipay/common/tracer/test/core/sofatracer/SofaTracerDemoTest.java
@@ -25,6 +25,7 @@ import com.alipay.common.tracer.core.generator.TraceIdGenerator;
 import com.alipay.common.tracer.core.holder.SofaTraceContextHolder;
 
 import com.alipay.common.tracer.core.span.SofaTracerSpan;
+import com.alipay.common.tracer.core.utils.MicroTimestamp;
 import com.alipay.common.tracer.core.utils.StringUtils;
 import com.alipay.common.tracer.test.base.AbstractTestBase;
 import com.alipay.common.tracer.test.core.sofatracer.type.TracerTestLogEnum;
@@ -143,8 +144,8 @@ public class SofaTracerDemoTest extends AbstractTestBase {
 
         String callServiceName = "callServiceName";
         //create server
-        SofaTracerSpan serverSpan = new SofaTracerSpan(tracer, System.currentTimeMillis(),
-            callServiceName, spanContext, null);
+        SofaTracerSpan serverSpan = new SofaTracerSpan(tracer,
+            MicroTimestamp.INSTANCE.currentMicroSeconds(), callServiceName, spanContext, null);
         serverSpan.setTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
         return serverSpan;
     }

--- a/tracer-test/core-test/src/test/java/com/alipay/common/tracer/test/core/sofatracer/SofaTracerStatisticsDemoTest.java
+++ b/tracer-test/core-test/src/test/java/com/alipay/common/tracer/test/core/sofatracer/SofaTracerStatisticsDemoTest.java
@@ -23,6 +23,7 @@ import com.alipay.common.tracer.core.context.trace.SofaTraceContext;
 import com.alipay.common.tracer.core.generator.TraceIdGenerator;
 import com.alipay.common.tracer.core.holder.SofaTraceContextHolder;
 import com.alipay.common.tracer.core.span.SofaTracerSpan;
+import com.alipay.common.tracer.core.utils.MicroTimestamp;
 import com.alipay.common.tracer.core.utils.StringUtils;
 import com.alipay.common.tracer.test.base.AbstractTestBase;
 import com.alipay.common.tracer.test.core.sofatracer.type.TracerTestLogEnum;
@@ -162,8 +163,8 @@ public class SofaTracerStatisticsDemoTest extends AbstractTestBase {
 
         String callServiceName = "callServiceName";
         //create server
-        SofaTracerSpan serverSpan = new SofaTracerSpan(tracer, System.currentTimeMillis(),
-            callServiceName, spanContext, null);
+        SofaTracerSpan serverSpan = new SofaTracerSpan(tracer,
+            MicroTimestamp.INSTANCE.currentMicroSeconds(), callServiceName, spanContext, null);
         serverSpan.setTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
         return serverSpan;
     }

--- a/tracer-test/core-test/src/test/java/com/alipay/common/tracer/test/core/sofatracer/encoder/ClientSpanEncoder.java
+++ b/tracer-test/core-test/src/test/java/com/alipay/common/tracer/test/core/sofatracer/encoder/ClientSpanEncoder.java
@@ -41,7 +41,7 @@ public class ClientSpanEncoder implements SpanEncoder<SofaTracerSpan> {
 
         SofaTracerSpanContext spanContext = span.getSofaTracerSpanContext();
         xsb.reset();
-        xsb.append(Timestamp.format(span.getEndTime()));
+        xsb.append(Timestamp.format(span.getEndTimeMillis()));
         //traceId
         xsb.append(spanContext.getTraceId());
         //spanId

--- a/tracer-test/core-test/src/test/java/com/alipay/common/tracer/test/core/sofatracer/encoder/ServerSpanEncoder.java
+++ b/tracer-test/core-test/src/test/java/com/alipay/common/tracer/test/core/sofatracer/encoder/ServerSpanEncoder.java
@@ -37,7 +37,7 @@ public class ServerSpanEncoder extends ClientSpanEncoder implements SpanEncoder<
     //        SofaTracerSpanContext spanContext = span.getSofaTracerSpanContext();
     //        xsb.reset();
     //
-    //        xsb.append(Timestamp.format(span.getStartTime())).append(span.getTagsWithStr())
+    //        xsb.append(Timestamp.format(span.getStartTimeMillis())).append(span.getTagsWithStr())
     //            .append(span.getTagsWithBool().toString()).append(span.getTagsWithNumber().toString())
     //            .appendEnd(spanContext.getBizBaggage());
     //


### PR DESCRIPTION
For Issue #19 

修改了类SofaTracerSpan的成员变量精度，从原来的毫秒提供到微秒精度（微秒级只为测量使用，不代表实际时间），以使向Zipkin输出span的duration能精确到微秒，同时使SofaTracerSpan原有方法getDurationMicrosecond的返回值符合其方法名称。

只是个尝试，如果实际应用中不要求测量方法级耗时精确到微秒，此番改动不具意义。
对于因为测试精度在毫秒级造成的duration为0，引起发往zipkin或者其他的报文中缺少duration域，导致接收端异常的情况，也可通过修改接收端代码来实现。
