### PR TITLE
add pid cache

### DIFF
--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/utils/TracerUtils.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/utils/TracerUtils.java
@@ -139,7 +139,7 @@ public class TracerUtils {
      */
     public static String getPID() {
         //缓存一次
-        if (P_ID_CACHE != null){
+        if (P_ID_CACHE != null) {
             return P_ID_CACHE;
         }
         String processName = java.lang.management.ManagementFactory.getRuntimeMXBean().getName();

--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/utils/TracerUtils.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/utils/TracerUtils.java
@@ -138,7 +138,7 @@ public class TracerUtils {
      * @return 进程 ID
      */
     public static String getPID() {
-        //缓存一次
+        //check pid is cached
         if (P_ID_CACHE != null) {
             return P_ID_CACHE;
         }

--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/utils/TracerUtils.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/utils/TracerUtils.java
@@ -45,6 +45,8 @@ public class TracerUtils {
     public static final String CURRENT_ZONE                                 = System
                                                                                 .getProperty(KEY_OF_CURRENT_ZONE);
 
+    public static String       P_ID_CACHE                                   = null;
+
     /**
      * Get trace id from current tracer context.
      *
@@ -136,6 +138,10 @@ public class TracerUtils {
      * @return 进程 ID
      */
     public static String getPID() {
+        //缓存一次
+        if (P_ID_CACHE != null){
+            return P_ID_CACHE;
+        }
         String processName = java.lang.management.ManagementFactory.getRuntimeMXBean().getName();
 
         if (StringUtils.isBlank(processName)) {
@@ -153,7 +159,7 @@ public class TracerUtils {
         if (StringUtils.isBlank(pid)) {
             return StringUtils.EMPTY_STRING;
         }
-
+        P_ID_CACHE = pid;
         return pid;
     }
 


### PR DESCRIPTION
### Motivation:

traceId生成过程中缓存PID

### Modification:

在TracerUtil类中增加一个静态变量 P_ID_CACHE ，当执行getPID()方法时先验证P_ID_CACHE是否为null，* 如果不为null则直接返回当前P_ID_CACHE 值
* 若果为null，则走正常获取pid的流程，最后将pid赋值给P_ID_CACHE

### Result:

Fixes #<11>. 
