### PR TITLE
Clean up dependencies of logging.

### DIFF
--- a/tracer-samples/tracer-sample-with-sofarpc/pom.xml
+++ b/tracer-samples/tracer-sample-with-sofarpc/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>rpc-sofa-boot-starter</artifactId>
             <version>5.4.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.alipay.sofa</groupId>

--- a/tracer-test/core-test/pom.xml
+++ b/tracer-test/core-test/pom.xml
@@ -62,12 +62,6 @@
         </dependency>
 
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>

--- a/tracer-test/core-test/pom.xml
+++ b/tracer-test/core-test/pom.xml
@@ -64,19 +64,17 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <version>1.2.16</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.6.6</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.6.6</version>
         </dependency>
 
     </dependencies>

--- a/tracer-test/log4j-test/pom.xml
+++ b/tracer-test/log4j-test/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <version>1.2.16</version>
         </dependency>
 
         <dependency>
@@ -33,7 +33,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.16</version>
         </dependency>
 
         <!-- stdout -->

--- a/tracer-test/log4j-test/pom.xml
+++ b/tracer-test/log4j-test/pom.xml
@@ -19,12 +19,6 @@
         </dependency>
 
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>


### PR DESCRIPTION
### Motivation:

SOFATracer project has multiple slf4j-api and slf4j adapter dependencies and in order to testing we optimize dependency to `1.7.21` governanced default by SOFABoot

### Modification:

Slf4j dependency optimization to `1.7.21`

### Result:

Fixes #39 