### PR TITLE
Fix typo of TracerLogRootDaemon.

### DIFF
--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/appender/TracerLogRootDaemon.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/appender/TracerLogRootDaemon.java
@@ -25,14 +25,14 @@ import java.io.File;
 import java.nio.charset.Charset;
 
 /**
- * TracerLogRootDeamon
+ * TracerLogRootDaemon
  *
  * 不从配置项目获取,直接从系统属性获取
  *
  * @author yangguanchao
  * @since 2017/06/25
  */
-public class TracerLogRootDeamon {
+public class TracerLogRootDaemon {
 
     /***
      * 是否添加 pid 到 log path

--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/appender/file/AbstractRollingFileAppender.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/appender/file/AbstractRollingFileAppender.java
@@ -17,7 +17,7 @@
 package com.alipay.common.tracer.core.appender.file;
 
 import com.alipay.common.tracer.core.appender.TraceAppender;
-import com.alipay.common.tracer.core.appender.TracerLogRootDeamon;
+import com.alipay.common.tracer.core.appender.TracerLogRootDaemon;
 import com.alipay.common.tracer.core.appender.self.SelfLog;
 
 import java.io.BufferedOutputStream;
@@ -63,7 +63,7 @@ public abstract class AbstractRollingFileAppender implements TraceAppender {
     }
 
     public AbstractRollingFileAppender(String file, int bufferSize, boolean append) {
-        this.fileName = TracerLogRootDeamon.LOG_FILE_DIR + File.separator + file;
+        this.fileName = TracerLogRootDaemon.LOG_FILE_DIR + File.separator + file;
         this.bufferSize = bufferSize;
         setFile(append);
     }
@@ -115,7 +115,7 @@ public abstract class AbstractRollingFileAppender implements TraceAppender {
                 }
             }
             // 无论有没有做 RollOver，都需要将输入往 bos 中写入
-            byte[] bytes = log.getBytes(TracerLogRootDeamon.DEFAULT_CHARSET);
+            byte[] bytes = log.getBytes(TracerLogRootDaemon.DEFAULT_CHARSET);
             write(bytes);
         }
     }

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/LogCleanupTest.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/LogCleanupTest.java
@@ -114,60 +114,60 @@ public class LogCleanupTest extends AbstractTestBase {
     }
 
     private void generateLogFilesToBeCleanupHourly(SimpleDateFormat sdf) throws IOException {
-        todayFile = newFile(TracerLogRootDeamon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG);
+        todayFile = newFile(TracerLogRootDaemon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG);
 
         Calendar oneHourAgo = Calendar.getInstance();
         oneHourAgo.add(Calendar.HOUR, -1);
-        yesterdayFile = newFile(TracerLogRootDeamon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
+        yesterdayFile = newFile(TracerLogRootDaemon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
                                 + sdf.format(oneHourAgo.getTime()));
 
         Calendar twoHourAgo = Calendar.getInstance();
         twoHourAgo.add(Calendar.HOUR, -2);
-        twoDayAgoFile = newFile(TracerLogRootDeamon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
+        twoDayAgoFile = newFile(TracerLogRootDaemon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
                                 + sdf.format(twoHourAgo.getTime()));
 
         Calendar threeHourAgo = Calendar.getInstance();
         threeHourAgo.add(Calendar.HOUR, -3);
-        threeDayAgoFile = newFile(TracerLogRootDeamon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
+        threeDayAgoFile = newFile(TracerLogRootDaemon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
                                   + sdf.format(threeHourAgo.getTime()));
 
         Calendar fourHourAgo = Calendar.getInstance();
         fourHourAgo.add(Calendar.HOUR, -4);
-        fourDayAgoFile = newFile(TracerLogRootDeamon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
+        fourDayAgoFile = newFile(TracerLogRootDaemon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
                                  + sdf.format(fourHourAgo.getTime()));
 
         Calendar fiveHourAgo = Calendar.getInstance();
         fiveHourAgo.add(Calendar.HOUR, -5);
-        fiveDayAgoFile = newFile(TracerLogRootDeamon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
+        fiveDayAgoFile = newFile(TracerLogRootDaemon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
                                  + sdf.format(fiveHourAgo.getTime()));
     }
 
     private void generateLogFilesToBeCleanup(SimpleDateFormat sdf) throws IOException {
-        todayFile = newFile(TracerLogRootDeamon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG);
+        todayFile = newFile(TracerLogRootDaemon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG);
 
         Calendar yesterday = Calendar.getInstance();
         yesterday.add(Calendar.DATE, -1);
-        yesterdayFile = newFile(TracerLogRootDeamon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
+        yesterdayFile = newFile(TracerLogRootDaemon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
                                 + sdf.format(yesterday.getTime()));
 
         Calendar twoDayAgo = Calendar.getInstance();
         twoDayAgo.add(Calendar.DATE, -2);
-        twoDayAgoFile = newFile(TracerLogRootDeamon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
+        twoDayAgoFile = newFile(TracerLogRootDaemon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
                                 + sdf.format(twoDayAgo.getTime()));
 
         Calendar threeDayAgo = Calendar.getInstance();
         threeDayAgo.add(Calendar.DATE, -3);
-        threeDayAgoFile = newFile(TracerLogRootDeamon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
+        threeDayAgoFile = newFile(TracerLogRootDaemon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
                                   + sdf.format(threeDayAgo.getTime()));
 
         Calendar fourDayAgo = Calendar.getInstance();
         fourDayAgo.add(Calendar.DATE, -4);
-        fourDayAgoFile = newFile(TracerLogRootDeamon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
+        fourDayAgoFile = newFile(TracerLogRootDaemon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
                                  + sdf.format(fourDayAgo.getTime()));
 
         Calendar fiveDayAgo = Calendar.getInstance();
         fiveDayAgo.add(Calendar.DATE, -5);
-        fiveDayAgoFile = newFile(TracerLogRootDeamon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
+        fiveDayAgoFile = newFile(TracerLogRootDaemon.LOG_FILE_DIR + "/" + CLEAN_UP_TEST_LOG
                                  + sdf.format(fiveDayAgo.getTime()));
     }
 

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/TracerLogRootDaemonTest.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/TracerLogRootDaemonTest.java
@@ -25,24 +25,24 @@ import java.io.File;
 import static junit.framework.TestCase.assertEquals;
 
 /**
- * TracerLogRootDeamon Tester.
+ * TracerLogRootDaemon Tester.
  *
  * @author <guanchao.ygc>
  * @version 1.0
  * @since <pre>七月 24, 2017</pre>
  */
-public class TracerLogRootDeamonTest {
+public class TracerLogRootDaemonTest {
 
     @Before
     public void before() throws Exception {
 
-        System.setProperty(TracerLogRootDeamon.TRACER_APPEND_PID_TO_LOG_PATH_KEY, "true");
+        System.setProperty(TracerLogRootDaemon.TRACER_APPEND_PID_TO_LOG_PATH_KEY, "true");
 
     }
 
     @After
     public void after() throws Exception {
-        System.clearProperty(TracerLogRootDeamon.TRACER_APPEND_PID_TO_LOG_PATH_KEY);
+        System.clearProperty(TracerLogRootDaemon.TRACER_APPEND_PID_TO_LOG_PATH_KEY);
     }
 
     //@Test
@@ -50,7 +50,7 @@ public class TracerLogRootDeamonTest {
         String traceLogRoot = System.getProperty("user.home") + File.separator + "logs";
         traceLogRoot += File.separator + "tracelog";
         traceLogRoot += File.separator + TracerUtils.getPID();
-        assertEquals(TracerLogRootDeamon.LOG_FILE_DIR, traceLogRoot);
+        assertEquals(TracerLogRootDaemon.LOG_FILE_DIR, traceLogRoot);
     }
 
 }

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/file/TimedRollingFileAppenderTest.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/file/TimedRollingFileAppenderTest.java
@@ -16,7 +16,7 @@
  */
 package com.alipay.common.tracer.core.appender.file;
 
-import com.alipay.common.tracer.core.appender.TracerLogRootDeamon;
+import com.alipay.common.tracer.core.appender.TracerLogRootDaemon;
 import com.alipay.common.tracer.core.base.AbstractTestBase;
 import com.alipay.common.tracer.core.utils.StringUtils;
 import org.apache.commons.io.FileUtils;
@@ -52,7 +52,7 @@ public class TimedRollingFileAppenderTest extends AbstractTestBase {
         TimeUnit.SECONDS.sleep(1);
         timedRollingFileAppender.append(content);
         timedRollingFileAppender.flush();
-        Resource[] resources = resolver.getResources("file:" + TracerLogRootDeamon.LOG_FILE_DIR
+        Resource[] resources = resolver.getResources("file:" + TracerLogRootDaemon.LOG_FILE_DIR
                                                      + File.separator + ROLLING_TEST_FILE_NAME
                                                      + "*");
         Assert.assertTrue("文件的数量不正确，以 " + ROLLING_TEST_FILE_NAME + " 为开头的文件数量应该是 2 个",

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/info/StaticInfoLogTest.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/info/StaticInfoLogTest.java
@@ -17,7 +17,7 @@
 package com.alipay.common.tracer.core.appender.info;
 
 import com.alipay.common.tracer.core.appender.TraceAppender;
-import com.alipay.common.tracer.core.appender.TracerLogRootDeamon;
+import com.alipay.common.tracer.core.appender.TracerLogRootDaemon;
 import com.alipay.common.tracer.core.appender.file.TimedRollingFileAppender;
 import com.alipay.common.tracer.core.base.AbstractTestBase;
 import com.alipay.common.tracer.core.utils.TracerUtils;
@@ -45,7 +45,7 @@ public class StaticInfoLogTest extends AbstractTestBase {
 
     @Before
     public void setup() {
-        File logDirectoryStaticInfoFile = new File(TracerLogRootDeamon.LOG_FILE_DIR
+        File logDirectoryStaticInfoFile = new File(TracerLogRootDaemon.LOG_FILE_DIR
                                                    + File.separator + "static-info.log");
         if (!logDirectoryStaticInfoFile.exists()) {
             return;
@@ -55,8 +55,8 @@ public class StaticInfoLogTest extends AbstractTestBase {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        assertTrue("LogRoot : " + TracerLogRootDeamon.LOG_FILE_DIR,
-            TracerLogRootDeamon.LOG_FILE_DIR.contains("tracelog"));
+        assertTrue("LogRoot : " + TracerLogRootDaemon.LOG_FILE_DIR,
+            TracerLogRootDaemon.LOG_FILE_DIR.contains("tracelog"));
     }
 
     @Test

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/manager/ConcurrentConsumerCorrectTest.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/manager/ConcurrentConsumerCorrectTest.java
@@ -17,7 +17,7 @@
 package com.alipay.common.tracer.core.appender.manager;
 
 import com.alipay.common.tracer.core.appender.TraceAppender;
-import com.alipay.common.tracer.core.appender.TracerLogRootDeamon;
+import com.alipay.common.tracer.core.appender.TracerLogRootDaemon;
 import com.alipay.common.tracer.core.appender.file.LoadTestAwareAppender;
 import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
 import com.alipay.common.tracer.core.span.SofaTracerSpan;
@@ -41,7 +41,7 @@ import java.util.concurrent.CountDownLatch;
  */
 public class ConcurrentConsumerCorrectTest {
 
-    static final String fileNameRoot = TracerLogRootDeamon.LOG_FILE_DIR + File.separator;
+    static final String fileNameRoot = TracerLogRootDaemon.LOG_FILE_DIR + File.separator;
     static final String fileName1    = "log1.log";
     static final String fileName2    = "log2.log";
     static final String fileName3    = "log3.log";

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/manager/ConcurrentDiscardTest.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/manager/ConcurrentDiscardTest.java
@@ -17,7 +17,7 @@
 package com.alipay.common.tracer.core.appender.manager;
 
 import com.alipay.common.tracer.core.appender.TraceAppender;
-import com.alipay.common.tracer.core.appender.TracerLogRootDeamon;
+import com.alipay.common.tracer.core.appender.TracerLogRootDaemon;
 import com.alipay.common.tracer.core.appender.file.LoadTestAwareAppender;
 import com.alipay.common.tracer.core.appender.self.SelfLog;
 import com.alipay.common.tracer.core.appender.self.SynchronizingSelfLog;
@@ -43,7 +43,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @version $Id: ConcurrentDiscardTest.java, v 0.1 2017年10月23日 下午8:22 liangen Exp $
  */
 public class ConcurrentDiscardTest {
-    static final String fileNameRoot    = TracerLogRootDeamon.LOG_FILE_DIR + File.separator;
+    static final String fileNameRoot    = TracerLogRootDaemon.LOG_FILE_DIR + File.separator;
     static final String fileName1       = "log1.log";
     static final String fileName2       = "log2.log";
     static final String fileName3       = "log3.log";

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/self/SelfLogTest.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/appender/self/SelfLogTest.java
@@ -16,7 +16,7 @@
  */
 package com.alipay.common.tracer.core.appender.self;
 
-import com.alipay.common.tracer.core.appender.TracerLogRootDeamon;
+import com.alipay.common.tracer.core.appender.TracerLogRootDaemon;
 import com.alipay.common.tracer.core.appender.manager.AsyncCommonAppenderManager;
 import com.alipay.common.tracer.core.base.AbstractTestBase;
 import org.apache.commons.io.FileUtils;
@@ -65,7 +65,7 @@ public class SelfLogTest extends AbstractTestBase {
         SelfLog.error("Error info", new RuntimeException("RunTimeException"));
         Thread.sleep(4000);
 
-        List<String> logs = FileUtils.readLines(new File(TracerLogRootDeamon.LOG_FILE_DIR
+        List<String> logs = FileUtils.readLines(new File(TracerLogRootDaemon.LOG_FILE_DIR
                                                          + File.separator + SelfLog.SELF_LOG_FILE));
         assertTrue(logs.size() > 0);
     }
@@ -77,7 +77,7 @@ public class SelfLogTest extends AbstractTestBase {
     public void testErrorWithTraceIdForLogE() throws Exception {
         SelfLog.errorWithTraceId("error Info ", "traceid");
         Thread.sleep(4000);
-        List<String> logs = FileUtils.readLines(new File(TracerLogRootDeamon.LOG_FILE_DIR
+        List<String> logs = FileUtils.readLines(new File(TracerLogRootDaemon.LOG_FILE_DIR
                                                          + File.separator + SelfLog.SELF_LOG_FILE));
         assertTrue(logs.toString(), logs.size() > 0);
     }
@@ -92,7 +92,7 @@ public class SelfLogTest extends AbstractTestBase {
 
         Thread.sleep(4000);
 
-        List<String> logs = FileUtils.readLines(new File(TracerLogRootDeamon.LOG_FILE_DIR
+        List<String> logs = FileUtils.readLines(new File(TracerLogRootDaemon.LOG_FILE_DIR
                                                          + File.separator + SelfLog.SELF_LOG_FILE));
         StringBuilder stringBuilder = new StringBuilder();
         for (int i = 0; i < logs.size(); i++) {


### PR DESCRIPTION
### Motivation:

Rename `TracerLogRootDeamon` to `TracerLogRootDaemon`.

### Result:

Fixes #35 
