### PR TITLE
Fix upgrade zipkin2

### DIFF
--- a/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springmvc/SpringMvcSofaTracerFilter.java
+++ b/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springmvc/SpringMvcSofaTracerFilter.java
@@ -133,6 +133,7 @@ public class SpringMvcSofaTracerFilter implements Filter {
         SofaTracer tracer = springMvcTracer.getSofaTracer();
         SofaTracerSpanContext spanContext = (SofaTracerSpanContext) tracer.extract(
             ExtendFormat.Builtin.B3_HTTP_HEADERS, new SpringMvcHeadersCarrier(headers));
+        spanContext.setSpanId(spanContext.nextChildContextId());
         return spanContext;
     }
 

--- a/tracer-sofa-boot-starter/pom.xml
+++ b/tracer-sofa-boot-starter/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>io.zipkin.zipkin2</groupId>
             <artifactId>zipkin</artifactId>
-            <version>2.11.1</version>
+            <version>2.11.3</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/zipkin/ZipkinSofaTracerSpanRemoteReporter.java
+++ b/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/zipkin/ZipkinSofaTracerSpanRemoteReporter.java
@@ -45,16 +45,18 @@ import java.util.Map;
  */
 public class ZipkinSofaTracerSpanRemoteReporter implements SpanReportListener, Flushable, Closeable {
 
-    private static String                  processId    = TracerUtils.getPID();
+    private static String                  processId           = TracerUtils.getPID();
 
     private final ZipkinRestTemplateSender sender;
 
     private final AsyncReporter<Span>      delegate;
 
+    private static final String            SOFARPC_TRACER_TYPE = "RPC_TRACER";
+
     /***
      * cache and performance improve
      */
-    private int                            ipAddressInt = -1;
+    private int                            ipAddressInt        = -1;
 
     public ZipkinSofaTracerSpanRemoteReporter(RestTemplate restTemplate, String baseUrl) {
         this.sender = new ZipkinRestTemplateSender(restTemplate, baseUrl);
@@ -134,7 +136,7 @@ public class ZipkinSofaTracerSpanRemoteReporter implements SpanReportListener, F
         //kind
         SofaTracer sofaTracer = sofaTracerSpan.getSofaTracer();
         // adapter SOFARpc span model
-        if ("RPC_TRACER".equals(sofaTracer.getTracerType())) {
+        if (SOFARPC_TRACER_TYPE.equals(sofaTracer.getTracerType())) {
             zipkinSpanBuilder.kind(Span.Kind.CLIENT);
         } else {
             zipkinSpanBuilder.kind(sofaTracerSpan.isClient() ? Span.Kind.CLIENT : Span.Kind.SERVER);

--- a/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/zipkin/ZipkinSofaTracerSpanRemoteReporter.java
+++ b/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/zipkin/ZipkinSofaTracerSpanRemoteReporter.java
@@ -134,7 +134,7 @@ public class ZipkinSofaTracerSpanRemoteReporter implements SpanReportListener, F
         //kind
         SofaTracer sofaTracer = sofaTracerSpan.getSofaTracer();
         // adapter SOFARpc span model
-        if (sofaTracer.getTracerType().equals("RPC_TRACER")) {
+        if ("RPC_TRACER".equals(sofaTracer.getTracerType())) {
             zipkinSpanBuilder.kind(Span.Kind.CLIENT);
         } else {
             zipkinSpanBuilder.kind(sofaTracerSpan.isClient() ? Span.Kind.CLIENT : Span.Kind.SERVER);


### PR DESCRIPTION
### Motivation:

1、resolve parentSpanId in Zipkin version 2.1.X report is blank .
2、adapter SOFARpc span to zipkin span 
3、upgrade zipkin version to 2.11.3 

### Result:

Fixes #57 . 

If there is no issue then describe the changes introduced by this PR.
