### PR TITLE
Fix aynsc servlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>tracer-all-parent</artifactId>
-    <version>2.1.3</version>
+    <version>2.1.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>tracer-all-parent</name>
@@ -31,7 +31,7 @@
 
     <properties>
         <opentracing.version>0.22.0</opentracing.version>
-        <sofa.tracer.version>2.1.3</sofa.tracer.version>
+        <sofa.tracer.version>2.1.4-SNAPSHOT</sofa.tracer.version>
         <java.compiler.source.version>1.6</java.compiler.source.version>
         <java.compiler.target.version>1.6</java.compiler.target.version>
         <jmh.version>1.9.3</jmh.version>

--- a/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-all/pom.xml
+++ b/tracer-all/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>tracer-all</artifactId>
-    <version>2.1.3</version>
+    <version>2.1.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>SOFATracer in one without SOFABoot starter</name>

--- a/tracer-core/pom.xml
+++ b/tracer-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tracer-extensions/pom.xml
+++ b/tracer-extensions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>tracer-extensions</artifactId>

--- a/tracer-samples/pom.xml
+++ b/tracer-samples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>tracer-all-parent</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tracer-samples/tracer-sample-with-slf4j/pom.xml
+++ b/tracer-samples/tracer-sample-with-slf4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>sofa-tracer-samples</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tracer-samples/tracer-sample-with-springmvc/pom.xml
+++ b/tracer-samples/tracer-sample-with-springmvc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>sofa-tracer-samples</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tracer-samples/tracer-sample-with-zipkin/pom.xml
+++ b/tracer-samples/tracer-sample-with-zipkin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>sofa-tracer-samples</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tracer-sofa-boot-plugin/pom.xml
+++ b/tracer-sofa-boot-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tracer-sofa-boot-starter/pom.xml
+++ b/tracer-sofa-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/controller/SampleRestController.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/controller/SampleRestController.java
@@ -20,6 +20,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.AsyncContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -51,6 +55,14 @@ public class SampleRestController {
         greeting.setId(counter.incrementAndGet());
         greeting.setContent("noDigestLog");
         return greeting;
+    }
+
+    @RequestMapping("/asyncServlet")
+    public void asyncServlet(HttpServletRequest request, HttpServletResponse response)
+                                                                                      throws IOException {
+        AsyncContext asyncContext = request.startAsync();
+        asyncContext.getResponse().getWriter().write("Hello World!");
+        asyncContext.complete();
     }
 
     public static class Greeting {

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/controller/SampleRestController.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/controller/SampleRestController.java
@@ -35,6 +35,8 @@ import java.util.concurrent.atomic.AtomicLong;
 @RestController
 public class SampleRestController {
 
+    public static String ASYNC_RESP = "Hello World!";
+
     private static final String template = "Hello, %s!";
 
     private final AtomicLong    counter  = new AtomicLong();
@@ -61,7 +63,7 @@ public class SampleRestController {
     public void asyncServlet(HttpServletRequest request, HttpServletResponse response)
                                                                                       throws IOException {
         AsyncContext asyncContext = request.startAsync();
-        asyncContext.getResponse().getWriter().write("Hello World!");
+        asyncContext.getResponse().getWriter().write(ASYNC_RESP);
         asyncContext.complete();
     }
 

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/springmvc/SpringMvcAsyncTest.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/springmvc/SpringMvcAsyncTest.java
@@ -19,6 +19,7 @@ package com.alipay.sofa.tracer.boot.springmvc;
 import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
 import com.alipay.common.tracer.core.reporter.digest.manager.SofaTracerDigestReporterAsyncManager;
 import com.alipay.sofa.tracer.boot.base.AbstractTestBase;
+import com.alipay.sofa.tracer.boot.base.controller.SampleRestController;
 import com.alipay.sofa.tracer.plugins.springmvc.SpringMvcLogEnum;
 import com.alipay.sofa.tracer.plugins.springmvc.SpringMvcTracer;
 import org.apache.commons.io.FileUtils;
@@ -56,6 +57,7 @@ public class SpringMvcAsyncTest extends AbstractTestBase {
 
         ResponseEntity<String> response = testRestTemplate.getForEntity(restUrl, String.class);
         String greetingResponse = response.getBody();
+        assertTrue(greetingResponse.equals(SampleRestController.ASYNC_RESP));
         assertTrue(response.getStatusCode() == HttpStatus.OK);
         // http://docs.spring.io/spring-boot/docs/1.4.2.RELEASE/reference/htmlsingle/#boot-features-testing
         Thread.sleep(3000);

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/springmvc/SpringMvcAsyncTest.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/springmvc/SpringMvcAsyncTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.boot.springmvc;
+
+import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
+import com.alipay.common.tracer.core.reporter.digest.manager.SofaTracerDigestReporterAsyncManager;
+import com.alipay.sofa.tracer.boot.base.AbstractTestBase;
+import com.alipay.sofa.tracer.plugins.springmvc.SpringMvcLogEnum;
+import com.alipay.sofa.tracer.plugins.springmvc.SpringMvcTracer;
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * SpringMvcFilterTest
+ *
+ * @author yangguanchao
+ * @since 2018/08/31
+ */
+@ActiveProfiles("json")
+public class SpringMvcAsyncTest extends AbstractTestBase {
+
+    @Test
+    public void testAsyncServlet() throws Exception {
+        //clear log file handler and reoutput
+        reflectSpringMVCClear();
+        //avoid close digest print
+        SofaTracerConfiguration.setProperty(SofaTracerConfiguration.DISABLE_DIGEST_LOG_KEY,
+            new HashMap<String, String>());
+        assertNotNull(testRestTemplate);
+        String restUrl = urlHttpPrefix + "/asyncServlet";
+
+        ResponseEntity<String> response = testRestTemplate.getForEntity(restUrl, String.class);
+        String greetingResponse = response.getBody();
+        assertTrue(response.getStatusCode() == HttpStatus.OK);
+        // http://docs.spring.io/spring-boot/docs/1.4.2.RELEASE/reference/htmlsingle/#boot-features-testing
+        Thread.sleep(3000);
+        //wait for async output
+        List<String> contents = FileUtils.readLines(new File(logDirectoryPath
+                                                             + File.separator
+                                                             + SpringMvcLogEnum.SPRING_MVC_DIGEST
+                                                                 .getDefaultLogName()));
+        assertTrue(contents.size() == 1);
+    }
+
+    private static void reflectSpringMVCClear() throws NoSuchFieldException, IllegalAccessException {
+        Field field = SpringMvcTracer.class.getDeclaredField("springMvcTracer");
+        field.setAccessible(true);
+        field.set(null, null);
+        //clear
+        Field fieldAsync = SofaTracerDigestReporterAsyncManager.class
+            .getDeclaredField("asyncCommonDigestAppenderManager");
+        fieldAsync.setAccessible(true);
+        fieldAsync.set(null, null);
+    }
+}

--- a/tracer-test/core-test/pom.xml
+++ b/tracer-test/core-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/log4j-test/pom.xml
+++ b/tracer-test/log4j-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.alipay.sofa</groupId>
             <artifactId>tracer-extensions</artifactId>
-            <version>2.1.3</version>
+            <version>2.1.4-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/tracer-test/log4j2-test/pom.xml
+++ b/tracer-test/log4j2-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/logback-test/pom.xml
+++ b/tracer-test/logback-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
### Motivation:

Fix aynsc servlet error like

```
llegalStateException: getOutputStream() has already been called for this response
```

### Modification:

Change the usage of the `HttpServletResponse` and avoid double call the `getOutputStream` method

### Result:

Fixes #62 

