### PR TITLE
When use httpclient print log ,if server response blank fix caused NPE

### DIFF
--- a/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/src/main/java/com/alipay/sofa/tracer/plugins/httpclient/interceptor/AbstractHttpRequestInterceptor.java
+++ b/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/src/main/java/com/alipay/sofa/tracer/plugins/httpclient/interceptor/AbstractHttpRequestInterceptor.java
@@ -81,8 +81,8 @@ public abstract class AbstractHttpRequestInterceptor {
         //length
         if (httpRequest instanceof HttpEntityEnclosingRequest) {
             HttpEntityEnclosingRequest httpEntityEnclosingRequest = (HttpEntityEnclosingRequest) httpRequest;
-            httpClientSpan.setTag(CommonSpanTags.REQ_SIZE, httpEntityEnclosingRequest.getEntity()
-                .getContentLength());
+            HttpEntity httpEntity = httpEntityEnclosingRequest.getEntity();
+            httpClientSpan.setTag(CommonSpanTags.REQ_SIZE, httpEntity == null ? -1 : httpEntity.getContentLength());
         }
         //carrier
         this.processHttpClientRequestCarrier(httpRequest, httpClientSpan);


### PR DESCRIPTION
### Motivation:

When use HttpClient print log ,if server response blank can cause NPE. SOFATracer should fix it.

### Modification:

Judge if server response is blank and set default value `-1`  as content length.

### Result:

Fixes #84 
