### PR TITLE
Fix spring cloud tracer error

### DIFF
--- a/tracer-sofa-boot-starter/pom.xml
+++ b/tracer-sofa-boot-starter/pom.xml
@@ -49,6 +49,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>infra-sofa-boot-starter</artifactId>
+        </dependency>
         <!-- optional -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/listener/SofaTracerConfigurationListener.java
+++ b/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/listener/SofaTracerConfigurationListener.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.tracer.boot.listener;
 
+import com.alipay.sofa.infra.utils.SOFABootEnvUtils;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.Bindable;
@@ -44,6 +45,10 @@ public class SofaTracerConfigurationListener
     @Override
     public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
         ConfigurableEnvironment environment = event.getEnvironment();
+
+        if (SOFABootEnvUtils.isSpringCloudBootstrapEnvironment(environment)) {
+            return;
+        }
 
         // check spring.application.name
         String applicationName = environment


### PR DESCRIPTION
As  application.properties can not be loaded during stage of spring cloud bootstrap,  execution of `SofaTracerConfigurationListener` should be skipped to avoid initialization of tracer log.