### PR TITLE
fix spring mvc appname lost

### DIFF
--- a/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/listener/SofaTracerConfigurationListener.java
+++ b/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/listener/SofaTracerConfigurationListener.java
@@ -55,6 +55,9 @@ public class SofaTracerConfigurationListener
             .getProperty(SofaTracerConfiguration.TRACER_APPNAME_KEY);
         Assert.isTrue(!StringUtils.isBlank(applicationName),
             SofaTracerConfiguration.TRACER_APPNAME_KEY + " must be configured!");
+        SofaTracerConfiguration.setProperty(SofaTracerConfiguration.TRACER_APPNAME_KEY,
+            applicationName);
+
         // set loggingPath
         String loggingPath = environment.getProperty("logging.path");
         if (StringUtils.isNotBlank(loggingPath)) {

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/AbstractTestBase.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/AbstractTestBase.java
@@ -17,11 +17,13 @@
 package com.alipay.sofa.tracer.boot.base;
 
 import com.alipay.common.tracer.core.appender.TracerLogRootDaemon;
+import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
 import com.alipay.common.tracer.core.reporter.digest.manager.SofaTracerDigestReporterAsyncManager;
 import com.alipay.common.tracer.core.reporter.stat.manager.SofaTracerStatisticReporterCycleTimesManager;
 import com.alipay.common.tracer.core.reporter.stat.manager.SofaTracerStatisticReporterManager;
 import com.alipay.sofa.tracer.plugins.springmvc.SpringMvcTracer;
 import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -102,5 +104,16 @@ public abstract class AbstractTestBase {
             .getDeclaredField("statReporters");
         fieldStat.setAccessible(true);
         fieldStat.set(statReporterManager, new ConcurrentHashMap<>());
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        clearTracerProperties();
+    }
+
+    private static void clearTracerProperties() throws Exception {
+        Field propertiesField = SofaTracerConfiguration.class.getDeclaredField("properties");
+        propertiesField.setAccessible(true);
+        propertiesField.set(null, new ConcurrentHashMap<>());
     }
 }

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/springmvc/SpringMvcFilterTest.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/springmvc/SpringMvcFilterTest.java
@@ -16,8 +16,6 @@
  */
 package com.alipay.sofa.tracer.boot.springmvc;
 
-import com.alipay.common.tracer.core.holder.SofaTraceContextHolder;
-import com.alipay.common.tracer.core.span.SofaTracerSpan;
 import com.alipay.sofa.tracer.boot.TestUtil;
 import com.alipay.sofa.tracer.boot.base.AbstractTestBase;
 import com.alipay.sofa.tracer.boot.base.controller.SampleRestController;
@@ -50,8 +48,6 @@ public class SpringMvcFilterTest extends AbstractTestBase {
     public void testSofaRestGet() throws Exception {
         assertNotNull(testRestTemplate);
         String restUrl = urlHttpPrefix + "/greeting";
-
-        SofaTracerSpan span = SofaTraceContextHolder.getSofaTraceContext().getCurrentSpan();
 
         ResponseEntity<SampleRestController.Greeting> response = testRestTemplate.getForEntity(
             restUrl, SampleRestController.Greeting.class);

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/springmvc/SpringMvcFilterTest.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/springmvc/SpringMvcFilterTest.java
@@ -16,17 +16,21 @@
  */
 package com.alipay.sofa.tracer.boot.springmvc;
 
+import com.alipay.common.tracer.core.holder.SofaTraceContextHolder;
+import com.alipay.common.tracer.core.span.SofaTracerSpan;
 import com.alipay.sofa.tracer.boot.TestUtil;
 import com.alipay.sofa.tracer.boot.base.AbstractTestBase;
 import com.alipay.sofa.tracer.boot.base.controller.SampleRestController;
 import com.alipay.sofa.tracer.plugins.springmvc.SpringMvcLogEnum;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -39,10 +43,15 @@ import static org.junit.Assert.assertTrue;
 @ActiveProfiles("zipkin")
 public class SpringMvcFilterTest extends AbstractTestBase {
 
+    @Value("${spring.application.name}")
+    private String appName;
+
     @Test
     public void testSofaRestGet() throws Exception {
         assertNotNull(testRestTemplate);
         String restUrl = urlHttpPrefix + "/greeting";
+
+        SofaTracerSpan span = SofaTraceContextHolder.getSofaTraceContext().getCurrentSpan();
 
         ResponseEntity<SampleRestController.Greeting> response = testRestTemplate.getForEntity(
             restUrl, SampleRestController.Greeting.class);
@@ -57,5 +66,8 @@ public class SpringMvcFilterTest extends AbstractTestBase {
         List<String> contents = FileUtils
             .readLines(customFileLog(SpringMvcLogEnum.SPRING_MVC_DIGEST.getDefaultLogName()));
         assertTrue(contents.size() == 1);
+
+        String logAppName = contents.get(0).split(",")[1];
+        assertEquals(appName, logAppName);
     }
 }


### PR DESCRIPTION
In SpringBoot Env, spring-mvc-digest.log lost the appName.

Before Fix:

```
2018-11-06 20:00:37.445,,a9feaa4d1541505599746100112444,0.1,http://localhost:8080/httpClientTracer,GET,200,-1B,0B,218ms,http-nio-8080-exec-1
```

After Fix:

```xml
2018-11-06 20:10:27.561,sofabootFrameworkTest,mytest,0.1,http://localhost:8080/httpClientTracer,GET,200,-1B,0B,122ms,http-nio-8080-exec-1,,
```